### PR TITLE
Fix Lucide type import

### DIFF
--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface FeatureCardProps {
   title: string;


### PR DESCRIPTION
## Summary
- use type-only import for `LucideIcon` in `FeatureCard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68404c223e308328811bf5af73992017