### PR TITLE
Add Navbar unit test with Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -28,6 +29,8 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "@testing-library/react": "^14.2.1",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Navbar } from '../Navbar';
+
+describe('Navbar', () => {
+  it('renders Funzionalità link', () => {
+    render(<Navbar />);
+    expect(screen.getByText('Funzionalità')).toBeTruthy();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- add vitest and testing-library packages
- configure vitest in vite.config
- add script to run vitest
- create Navbar test checking for "Funzionalità" link

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404c2c70f08328a4e690322ee089fb